### PR TITLE
Pin orbax-checkpoint to 0.11.23 to avoid compatibility issue with jax==0.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ def get_base_requirements():
     return [
         "jax[cuda12]==0.5.3",
         "flax==0.10.5",
+        "orbax-checkpoint==0.11.23",
         "gymnasium",
         "gymnasium_robotics",
         'shimmy==1.3.0',


### PR DESCRIPTION
This PR addresses a dependency conflict that can occur when users have `jax==0.5.3` installed and do not specify an upper bound for the `orbax-checkpoint` dependency.

The issue is as follows:

1.  `flow-rl` currently requires `jax==0.5.3` and does not specify an upper bound for the `orbax-checkpoint` dependency.
2.  `orbax-checkpoint` version `0.11.24` [introduced a call to `jax.monitoring.record_scalar`](https://github.com/google/orbax/commit/4242cee300a4de5e2ba3fb84942288d7c439e179), which only exists in `jax>=0.6.0`.
3.  `orbax-checkpoint` version `0.11.24` did not enforce a `jax>=0.6.0` dependency, allowing it to be installed alongside `jax==0.5.3`.
4.  Although [`orbax-checkpoint` version `0.11.25` corrected this by adding the `jax>=0.6.0` requirement](https://github.com/google/orbax/issues/2368), version `0.11.24` remains available on PyPI, leading to installation and runtime failures for users with the current dependency setup of `flow-rl`.

**Solution:** This PR pins the `orbax-checkpoint` dependency to `0.11.23`, the newest version which does not require `jax>=0.6.0`.