### PR TITLE
[bugfix]: change default float format from tf32 to fp32

### DIFF
--- a/examples/online/main_dmc_offpolicy.py
+++ b/examples/online/main_dmc_offpolicy.py
@@ -2,6 +2,7 @@ import os
 
 import gymnasium as gym
 import hydra
+import jax
 import jax.numpy as jnp
 import numpy as np
 import omegaconf
@@ -16,6 +17,8 @@ from flowrl.env.online.dmc_env import DMControlEnv
 from flowrl.types import *
 from flowrl.utils.logger import CompositeLogger
 from flowrl.utils.misc import set_seed_everywhere
+
+jax.config.update("jax_default_matmul_precision", "float32")
 
 SUPPORTED_AGENTS: Dict[str, BaseAgent] = {
     "sac": SACAgent,

--- a/examples/online/main_mujoco_offpolicy.py
+++ b/examples/online/main_mujoco_offpolicy.py
@@ -3,6 +3,7 @@ import os
 import gymnasium as gym
 import gymnasium_robotics
 import hydra
+import jax
 import numpy as np
 import omegaconf
 import wandb
@@ -15,6 +16,8 @@ from flowrl.dataset.buffer.state import ReplayBuffer
 from flowrl.types import *
 from flowrl.utils.logger import CompositeLogger
 from flowrl.utils.misc import set_seed_everywhere
+
+jax.config.update("jax_default_matmul_precision", "float32")
 
 SUPPORTED_AGENTS: Dict[str, BaseAgent] = {
     "sac": SACAgent,

--- a/examples/online/main_mujoco_onpolicy.py
+++ b/examples/online/main_mujoco_onpolicy.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple
 import gymnasium as gym
 import gymnasium_robotics
 import hydra
+import jax
 import jax.numpy as jnp
 import numpy as np
 import wandb
@@ -15,6 +16,8 @@ from flowrl.config.online.mujoco import Config
 from flowrl.types import *
 from flowrl.utils.logger import CompositeLogger
 from flowrl.utils.misc import set_seed_everywhere
+
+jax.config.update("jax_default_matmul_precision", "float32")
 
 SUPPORTED_AGENTS: Dict[str, BaseAgent] = {
     "ppo": PPOAgent,


### PR DESCRIPTION
We identified a severe issue w.r.t. the default float precision: 

Recent architectures like Ampere (A100) and Ada Lovelace (L40S) introduced a new float format `tf32` to replace `fp32`. JAX will use `tf32` whenever it is available; however, PyTorch uses `fp32` for matrix multiplication and only uses `tf32` for convolution. Operators requiring higher float precision, such as `softmax`, may function incorrectly or produce unexpected results under JAX's default settings.

<img width="300" height="888" alt="image" src="https://github.com/user-attachments/assets/9e82b50e-7486-43f9-bad7-5895dcf737ba" />

cc. @cmj2002 @echen333 