### PR TITLE
Respect optional IsaacLab action bounds

### DIFF
--- a/examples/online/main_isaaclab_onpolicy.py
+++ b/examples/online/main_isaaclab_onpolicy.py
@@ -116,7 +116,11 @@ class IsaacLabOnPolicyTrainer:
                 jnp.array(obs_norm), deterministic=False
             )
             actions_np = np.array(actions)
-            actions_clipped = np.clip(actions_np, -1.0, 1.0)
+            actions_env = (
+                np.clip(actions_np, -1.0, 1.0)
+                if self.env.action_bound is not None
+                else actions_np
+            )
             all_actions[t] = actions_np
 
             # Generically collect algorithm-specific info
@@ -128,7 +132,7 @@ class IsaacLabOnPolicyTrainer:
             for k, v in info.items():
                 all_extras[k][t] = np.array(v)
 
-            next_obs, rewards, terminated, truncated, infos = self.env.step(actions_clipped)
+            next_obs, rewards, terminated, truncated, infos = self.env.step(actions_env)
 
             all_rewards[t] = rewards[..., np.newaxis]
             all_terminated[t] = terminated[..., np.newaxis]
@@ -209,8 +213,13 @@ class IsaacLabOnPolicyTrainer:
             actions, _ = self.agent.sample_actions(
                 jnp.array(obs_norm), deterministic=True
             )
-            actions_clipped = np.clip(np.array(actions), -1.0, 1.0)
-            obs, rewards, terminated, truncated, _ = self.env.step(actions_clipped)
+            actions_np = np.array(actions)
+            actions_env = (
+                np.clip(actions_np, -1.0, 1.0)
+                if self.env.action_bound is not None
+                else actions_np
+            )
+            obs, rewards, terminated, truncated, _ = self.env.step(actions_env)
 
             eval_returns += rewards * (1 - eval_dones)
             eval_lengths += 1 * (1 - eval_dones)

--- a/flowrl/config/online/onpolicy_isaaclab_config.py
+++ b/flowrl/config/online/onpolicy_isaaclab_config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from .hb_config import EvalConfig, LogConfig
 
@@ -10,7 +10,7 @@ class Config:
     device: str
     task: str
     algo: Any
-    action_bound: float
+    action_bound: Optional[float]
     disable_bootstrap: bool
     norm_obs: bool
     train_frames: int


### PR DESCRIPTION
## Summary

- Pass raw actions through the IsaacLab on-policy trainer when `action_bound` is unset.
- Keep the existing normalised-action path when `action_bound` is set by clipping to `[-1, 1]` before the environment wrapper scales the action.
- Mark `action_bound` as `Optional[float]` so `null` is a valid configuration value.

## Rationale

IsaacLab does not impose a global `[-1, 1]` action limit for every task. Some tasks use unbounded policy actions and then apply task-specific scaling, action-term clipping, or actuator limits. The previous trainer behaviour clipped actions unconditionally before calling `env.step`, even when the wrapper was configured with `action_bound=None`.

That made `action_bound=None` ineffective and could change the interaction semantics for policies that intentionally emit actions outside `[-1, 1]`, such as flow-based on-policy agents. With this change, the environment adapter remains responsible for bounded-action semantics: if `action_bound` is provided, actions are clipped and scaled; if it is not provided, actions are passed through unchanged.

## Validation

- Ran a syntax check with Python `compile()` for:
  - `examples/online/main_isaaclab_onpolicy.py`
  - `flowrl/config/online/onpolicy_isaaclab_config.py`
